### PR TITLE
Fix:display actual points for child from mock data with fallback

### DIFF
--- a/frontend/app/(dashboards)/child-dashboard/page.tsx
+++ b/frontend/app/(dashboards)/child-dashboard/page.tsx
@@ -41,7 +41,7 @@ export default function ChildDashboard() {
           </div>
           <div className="flex items-center space-x-4">
             <div className="bg-yellow-100 text-yellow-800 px-4 py-2 rounded-full font-semibold">
-              ⭐ 0 Points
+              ⭐ {currentUser.points ?? 0} Points
             </div>
             <button
               onClick={handleLogout}


### PR DESCRIPTION
1. The child dashboard previously showed 0 points hardcoded.
2. This update fetches the points from the logged-in child (via getCurrentUser()).
3. In cases when the  points are not defined, it falls back to 0.

Test Case:
When logged in as child with points: shows actual points.



