### PR TITLE
Docs:  Update git-workflow doc with instructions on separating backend and frontend related matters

### DIFF
--- a/doc/data-design.md
+++ b/doc/data-design.md
@@ -5,11 +5,11 @@
 
 This is extremly simple flow.
 
-
 # Data Modesl
 
-### User 
-```
+### User
+
+```ts
 User {
   id: string (UUID) // PK
   name: string
@@ -28,8 +28,10 @@ User {
   rewardsRequested: RewardRedemption[]
 }
 ```
+
 ### Chore
-```
+
+```ts
 Chore {
   id: string (UUID) // PK
   title: string
@@ -49,8 +51,10 @@ Chore {
   assignedBy: User
 }
 ```  
+
 ### Reward
-```
+
+```ts
 Reward {
   id: string (UUID) // PK
   name: string
@@ -65,8 +69,10 @@ Reward {
   redemptions: RewardRedemption[]
 }
 ```
+
 ### RewardRedemption
-```
+
+```ts
 RewardRedemption {
   id: string (UUID) // PK
   rewardId: string // FK → Reward
@@ -82,8 +88,10 @@ RewardRedemption {
   approvedBy: User | null
 }
 ```
+
 ### Badge (optional)
-```
+
+```ts
 Badge {
   id: string (UUID) // PK
   name: string
@@ -92,8 +100,10 @@ Badge {
   condition: string // logic to determine when earned
 }
 ```
+
 ### UserBadge (optional)
-```
+
+```ts
 UserBadge {
   id: string (UUID)
   userId: string // FK → User

--- a/doc/git-workflow.md
+++ b/doc/git-workflow.md
@@ -1,20 +1,27 @@
 # Git Workflow for Team Collaboration
 
 ## Before You Start
-1. **Clone the project** (first time only):
+
+### 1. **Clone the project** (first time only)
+
 ```bash
 git clone https://github.com/freeCodeCamp-2025-Summer-Hackathon/lime-variable.git
 ```
+
 or
+
 ```bash
 git clone git@github.com:freeCodeCamp-2025-Summer-Hackathon/lime-variable.git
 ```
+
 then
+
 ```bash
 cd lime-variable
 ```
 
-2. **Always start with the latest code**:
+### 2. **Always start with the latest code**
+
 ```bash
 git checkout main
 git pull origin main
@@ -23,6 +30,7 @@ git pull origin main
 ## Daily Workflow
 
 ### 1. Create a Feature Branch
+
 ```bash
 # Always create from main
 git checkout main
@@ -31,16 +39,21 @@ git checkout -b feature/your-feature-name
 ```
 
 **Branch naming conventions:**
-- `feature/add-login-page`
+
+- `when working with frontend or backend then provide your branch with fe- or be- prefix`
+- `be-feature/add-user-model`
+- `fe-feature/add-login-page`
 - `bugfix/fix-navbar-issue`
 - `hotfix/security-patch`
 
 ### 2. Work on Your Changes
+
 - Make your code changes
 - Test your work locally
 - Keep commits small and focused
 
 ### 3. Commit Your Work
+
 ```bash
 # Stage your changes
 git add .
@@ -53,7 +66,8 @@ git commit -m "feat: Add user authentication to login page"
 
 ```
 
-### More Examples of commit messages 
+### More Examples of commit messages
+
 ```bash
 # New features
 git commit -m "feat: add shopping cart functionality"
@@ -76,6 +90,7 @@ git commit -m "chore: update dependencies to latest versions"
 ```
 
 **Good commit messages tell a story:**
+
 - ❌ "fixed stuff"
 - ❌ "update"
 - ❌ "changes"
@@ -84,11 +99,13 @@ git commit -m "chore: update dependencies to latest versions"
 - ✅ "docs: add API usage examples"
 
 ### 4. Push Your Branch
+
 ```bash
 git push origin feature/your-feature-name
 ```
 
 ### 5. Create a Pull Request (PR)
+
 1. Go to project github repo
 2. Click "New Pull Request"
 3. Choose: `your-branch` → `main`
@@ -96,11 +113,13 @@ git push origin feature/your-feature-name
 5. Request reviewers (teammates)
 
 ### 6. Handle Code Review
+
 - Teammates will review your code
 - Make requested changes on your branch
 - Push updates (they'll appear in the same PR)
 
 ### 7. After PR is Merged
+
 ```bash
 # Switch back to main
 git checkout main
@@ -117,12 +136,14 @@ git push origin --delete feature/your-feature-name
 
 ## Important Rules for The Project
 
-### ⚠️ Never Do This:
+### ⚠️ Never Do This
+
 - Don't push directly to `main` branch
 - Don't force push (`git push --force`) on shared branches
 - Don't commit large files or sensitive data
 
-### ✅ Always Do This:
+### ✅ Always Do This
+
 - Pull latest changes before starting new work
 - Test your code before pushing
 - Write clear commit messages
@@ -155,7 +176,8 @@ git merge main
 
 ## When Things Go Wrong
 
-### Accidentally committed to main:
+### Accidentally committed to main
+
 ```bash
 # Don't panic! Create a branch from your commit
 git branch feature/my-work
@@ -164,7 +186,8 @@ git reset --hard HEAD~1  # Remove the commit from main
 git checkout feature/my-work
 ```
 
-### Need to update your branch with latest main:
+### Need to update your branch with latest main
+
 ```bash
 git checkout main
 git pull origin main
@@ -172,12 +195,12 @@ git checkout your-branch
 git merge main
 ```
 
-### Merge conflicts:
+### Merge conflicts
+
 1. Git will mark conflicted files
 2. Open files and look for `<<<<<<<`, `=======`, `>>>>>>>`
 3. Choose which code to keep
 4. Remove the conflict markers
 5. `git add .` and `git commit`
-
 
 Remember: It's okay to make mistakes - that's how you learn!


### PR DESCRIPTION
Git-workflow doc should have instructions on providing the issues, commits and pull requests with be- and fe- prefixes, so we can separate backend and frontend related things.

Addresses [issue 26]( https://github.com/freeCodeCamp-2025-Summer-Hackathon/lime-variable/issues/26)