### PR TITLE
Chore/GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,67 @@
+name: Bug Report
+description: Report a reproducible bug in the application.
+title: "[Bug] "
+labels: ["type: bug", "triage"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please provide the following information to help us investigate.
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: What browser, device, or system did you use?
+      placeholder: "e.g., Chrome 124 on Windows 10"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Provide clear steps to reproduce the issue.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See the error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: "It should have..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+      placeholder: "Instead, it..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or Logs
+      description: Attach screenshots or logs if applicable.
+      placeholder: "You can drag images here or paste logs."
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Before submitting
+      options:
+        - label: I've checked for existing issues related to this bug.
+          required: true
+        - label: I've filled in all required fields.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -2,6 +2,7 @@ name: Bug Report
 description: Report a reproducible bug in the application.
 title: "[Bug] "
 labels: ["type: bug", "triage"]
+projects: ["Frontend", "Backend"]
 assignees: []
 
 body:

--- a/.github/ISSUE_TEMPLATE/bug_report_team.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_team.yaml
@@ -1,0 +1,79 @@
+name: Team Bug Report
+description: For internal teams to report bugs with more technical details.
+title: "[Team Bug] "
+labels: ["type: bug", "from: team", "triage"]
+assignees:
+  - SampleAssignee
+
+body:
+  - type: input
+    id: reporter
+    attributes:
+      label: Reporter
+      description: Who is reporting this bug?
+      placeholder: "e.g., stbs(backend)"
+    validations:
+      required: true
+
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical – blocks functionality or deployment
+        - Major – impacts primary functionality
+        - Minor – UI/UX or non-blocking issues
+        - Low – cosmetic or trivial
+    validations:
+      required: true
+
+  - type: input
+    id: component
+    attributes:
+      label: Affected Component
+      placeholder: "e.g., Login page, API: /auth/login"
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Clear steps for reproducing the bug.
+      placeholder: |
+        1. Open...
+        2. Click...
+        3. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      placeholder: "Describe what should have happened"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      placeholder: "Describe what actually happened"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Logs, screenshots, test case IDs, links to Slack or Notion, etc.
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Checklist
+      options:
+        - label: I confirmed this bug is not a duplicate.
+          required: true
+        - label: The bug is reproducible on the latest version.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report_team.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_team.yaml
@@ -2,6 +2,7 @@ name: Team Bug Report
 description: For internal teams to report bugs with more technical details.
 title: "[Team Bug] "
 labels: ["type: bug", "from: team", "triage"]
+projects: ["Frontend", "Backend"]
 assignees:
   - SampleAssignee
 

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,65 @@
+name: Feature Request
+description: Propose a new feature or improvement.
+title: "[Feature] "
+labels: ["type: feature", "triage"]
+projects: ["Frontend", "Backend"]
+assignees: "SampleAssignee"
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature! Please provide as much detail as possible.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Feature Summary
+      description: What is the feature or improvement?
+      placeholder: "e.g., Add dark mode support"
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case / Problem
+      description: What problem does this solve or what use case does it support?
+      placeholder: "Users need this because..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe how you imagine the feature working.
+      placeholder: "Add a toggle in settings..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered other approaches?
+      placeholder: "We also considered..."
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - High – needed for current milestone
+        - Medium – nice to have soon
+        - Low – no urgency
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I've searched for existing feature requests.
+          required: true

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -1,0 +1,52 @@
+name: Task
+description: Log a task that needs to be completed.
+title: "[Task] "
+labels: ["type: task"]
+projects: ["Frontend", "Backend"]
+
+assignees: 'SampleAssignee'
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Create a task for things like refactoring, configuration, or setup. Not for bugs or features.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Task Summary
+      placeholder: "e.g., Set up staging environment"
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Task Details
+      description: What exactly needs to be done?
+      placeholder: |
+        - Set up Firebase project
+        - Configure staging DB
+        - Add `.env.staging` file
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - High – blocks other work
+        - Medium – must be done soon
+        - Low – whenever possible
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: This is not a bug or feature request.
+          required: true


### PR DESCRIPTION
Create an issue template for the repo

### Issue template
- bug template
- bug template for the team
- feature template
- task template

iI got an error when i try to make config,yaml. the editor is saying `Property blank_issues_enabled is not allowed.yaml-schema: GitHub Issue Template forms(513)` when i put the `blank_issues_enabled` and `issue_template`. searched for a solution and what i found is that if the file type is `.yaml` no need to add it, if it's `.yml` it needs config file.

Closes #2