### PR TITLE
fix: Change link to correct one

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Turns everyday chores into a fun, rewarding experience. Designed for families, i
 
 ## 🌐 Deployed version
 
-https://lime-variables.vercel.app/
+https://lime-variable.vercel.app/
 
 ## 🛠️ Tech Stack
 


### PR DESCRIPTION
Readme.md had a typo in the website link, which made it redirect to the wrong site.